### PR TITLE
support multiple paths for a browser

### DIFF
--- a/ViewInBrowserCommand.py
+++ b/ViewInBrowserCommand.py
@@ -111,6 +111,12 @@ class ViewInBrowserCommand(sublime_plugin.TextCommand):
 				for env in supportedBrowsers[selectedBrowser]:
 					print "OS name: %s, Platform: %s" % (env["osname"], env["platform"])
 
+					if type(env["command"]) == list:
+						for cmd in env["command"]:
+							if os.path.exists(cmd):
+								env["command"] = cmd
+								break
+
 					if re.match(env["osname"], osname) and re.match(env["platform"], platform):
 						print "Match! %s" % env["command"]
 


### PR DESCRIPTION
Allow multiple paths to be specified for a single browser. This change will select the first path that exists.  Example:

``` javascript
    "command": [
        "c:/Program Files/Mozilla FireFox/firefox.exe",
        "c:/Program Files (x86)/Mozilla Firefox/firefox.exe"
    ]
```

This can be useful when running a portable installation of Sublime and the configuation is shared (for example, on DropBox) and different machines have browsers in different locations.
