### PR TITLE
fix errors on ubuntu 14.04LTS

### DIFF
--- a/View In Browser.sublime-settings
+++ b/View In Browser.sublime-settings
@@ -6,7 +6,12 @@
 			"chrome64": "google-chrome",
 			"chromium": "chromium"
 		},
-
+		"linux2": {
+			"firefox": "firefox -new-tab",
+			"chrome": "google-chrome",
+			"chrome64": "google-chrome",
+			"chromium": "chromium"
+		},
 		"darwin": {
 			"firefox": "open -a \"/Applications/Firefox.app\"",
 			"safari": "open -a \"/Applications/Safari.app\"",

--- a/ViewInBrowserCommand.py
+++ b/ViewInBrowserCommand.py
@@ -229,7 +229,7 @@ class ViewInBrowserCommand(sublime_plugin.TextCommand):
 		# command to open this file. Otherwise use the system default.
 		#
 		if pluginSettings["baseCommand"]:
-			command = "%s %s" % (pluginSettings["baseCommand"], fileToOpen.encode(sys.getfilesystemencoding()) if self._pythonVersion < 3 else fileToOpen,)
+			command = "%s %s" % (pluginSettings["baseCommand"], fileToOpen.decode().encode(sys.getfilesystemencoding()) if self._pythonVersion < 3 else fileToOpen,)
 
 			print(command)
 			self.openBrowser(command, self.getOsName())


### PR DESCRIPTION
I fixed two errors here
Ubuntu is seen as linux2, so i added linux2 key in sublime-settings
Use decode() before encode, avoid "'ascii' codec can't decode byte 0xc3 in position 24: ordinal not in range(128)" error

Work perfectly after those changes
